### PR TITLE
Fix Docker build path to correctly locate go.mod

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,11 +10,11 @@ RUN npm run build
 
 # Stage 2: build backend
 FROM golang:1.24.3 AS backend-builder
-WORKDIR /app
-COPY server/go.mod server/go.sum ./server/
-RUN cd server && go mod download
-COPY server ./server
-RUN CGO_ENABLED=0 go build -o netgraph ./server
+WORKDIR /app/server
+COPY server/go.mod server/go.sum ./
+RUN go mod download
+COPY server .
+RUN CGO_ENABLED=0 go build -o /app/netgraph
 
 # Final stage
 FROM alpine


### PR DESCRIPTION
## Summary
- set backend builder `WORKDIR` to `/app/server`
- copy Go module files directly into the working directory
- build the Go backend from within the module directory

This resolves errors during `docker compose build` where Go could not find `go.mod`.

## Testing
- `go vet` on the server package

------
https://chatgpt.com/codex/tasks/task_e_68886c1ef7dc832b94f370c1c555bb44