### PR TITLE
Adjust compose port and full-page graph

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,4 +3,4 @@ services:
   netgraph:
     build: .
     ports:
-      - "8080:8080"
+      - "9080:8080"

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -11,8 +11,9 @@ onMount(async () => {
 
 function draw(){
     const svg = d3.select('#graph');
-    const width = +svg.attr('width');
-    const height = +svg.attr('height');
+    const width = window.innerWidth;
+    const height = window.innerHeight;
+    svg.attr('width', width).attr('height', height);
 
     const simulation = d3.forceSimulation(graph.nodes)
         .force('link', d3.forceLink(graph.links).id(d => d.id).distance(100))
@@ -69,10 +70,16 @@ function draw(){
 </script>
 
 <main>
-    <svg id="graph" width="600" height="400"></svg>
+    <svg id="graph" style="width:100%; height:100%;"></svg>
 </main>
 
 <style>
+main,
+svg {
+    width: 100%;
+    height: 100%;
+}
+
 svg {
     border: 1px solid #ccc;
 }


### PR DESCRIPTION
## Summary
- expose the service on host port `9080`
- size the graph to fill the whole viewport

## Testing
- `go build`
- `npm install && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68886d711458832bbf5aba7f158cd3f0