### PR TITLE
Add typed nodes with icons

### DIFF
--- a/data/graph.json
+++ b/data/graph.json
@@ -1,9 +1,9 @@
 {
   "nodes": [
-    {"id": "A"},
-    {"id": "B"},
-    {"id": "C"},
-    {"id": "D"}
+    {"id": "A", "type": "net"},
+    {"id": "B", "type": "host"},
+    {"id": "C", "type": "rtr"},
+    {"id": "D", "type": "fw"}
   ],
   "links": [
     {"source": "A", "target": "B"},

--- a/frontend/public/icons/computer-desktop.svg
+++ b/frontend/public/icons/computer-desktop.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-slot="icon">
+  <path stroke-linecap="round" stroke-linejoin="round" d="M9 17.25v1.007a3 3 0 0 1-.879 2.122L7.5 21h9l-.621-.621A3 3 0 0 1 15 18.257V17.25m6-12V15a2.25 2.25 0 0 1-2.25 2.25H5.25A2.25 2.25 0 0 1 3 15V5.25m18 0A2.25 2.25 0 0 0 18.75 3H5.25A2.25 2.25 0 0 0 3 5.25m18 0V12a2.25 2.25 0 0 1-2.25 2.25H5.25A2.25 2.25 0 0 1 3 12V5.25"/>
+</svg>

--- a/frontend/public/icons/server-stack.svg
+++ b/frontend/public/icons/server-stack.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-slot="icon">
+  <path stroke-linecap="round" stroke-linejoin="round" d="M5.25 14.25h13.5m-13.5 0a3 3 0 0 1-3-3m3 3a3 3 0 1 0 0 6h13.5a3 3 0 1 0 0-6m-16.5-3a3 3 0 0 1 3-3h13.5a3 3 0 0 1 3 3m-19.5 0a4.5 4.5 0 0 1 .9-2.7L5.737 5.1a3.375 3.375 0 0 1 2.7-1.35h7.126c1.062 0 2.062.5 2.7 1.35l2.587 3.45a4.5 4.5 0 0 1 .9 2.7m0 0a3 3 0 0 1-3 3m0 3h.008v.008h-.008v-.008Zm0-6h.008v.008h-.008v-.008Zm-3 6h.008v.008h-.008v-.008Zm0-6h.008v.008h-.008v-.008Z"/>
+</svg>

--- a/frontend/public/icons/shield-check.svg
+++ b/frontend/public/icons/shield-check.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-slot="icon">
+  <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75 11.25 15 15 9.75m-3-7.036A11.959 11.959 0 0 1 3.598 6 11.99 11.99 0 0 0 3 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285Z"/>
+</svg>

--- a/frontend/public/icons/wifi.svg
+++ b/frontend/public/icons/wifi.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-slot="icon">
+  <path stroke-linecap="round" stroke-linejoin="round" d="M8.288 15.038a5.25 5.25 0 0 1 7.424 0M5.106 11.856c3.807-3.808 9.98-3.808 13.788 0M1.924 8.674c5.565-5.565 14.587-5.565 20.152 0M12.53 18.22l-.53.53-.53-.53a.75.75 0 0 1 1.06 0Z"/>
+</svg>

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -1,6 +1,14 @@
 <script>
 import { onMount } from 'svelte';
 import * as d3 from 'd3';
+
+const icons = {
+    net: '/icons/wifi.svg',
+    host: '/icons/computer-desktop.svg',
+    rtr: '/icons/server-stack.svg',
+    fw: '/icons/shield-check.svg'
+};
+
 let graph = {nodes:[], links:[]};
 
 onMount(async () => {
@@ -27,12 +35,14 @@ function draw(){
         .enter().append('line');
 
     const node = svg.append('g')
-        .attr('stroke', '#fff')
-        .attr('stroke-width', 1.5)
-        .selectAll('circle')
+        .selectAll('image')
         .data(graph.nodes)
-        .enter().append('circle')
-        .attr('r', 8)
+        .enter().append('image')
+        .attr('href', d => icons[d.type])
+        .attr('width', 24)
+        .attr('height', 24)
+        .attr('x', -12)
+        .attr('y', -12)
         .call(d3.drag()
             .on('start', dragstarted)
             .on('drag', dragged)
@@ -46,8 +56,7 @@ function draw(){
             .attr('x2', d => d.target.x)
             .attr('y2', d => d.target.y);
 
-        node.attr('cx', d => d.x)
-            .attr('cy', d => d.y);
+        node.attr('transform', d => `translate(${d.x},${d.y})`);
     });
 
     function dragstarted(event) {

--- a/server/main.go
+++ b/server/main.go
@@ -1,55 +1,56 @@
 package main
 
 import (
-    "encoding/json"
-    "log"
-    "net/http"
-    "os"
+	"encoding/json"
+	"log"
+	"net/http"
+	"os"
 
-    "github.com/gorilla/mux"
+	"github.com/gorilla/mux"
 )
 
 type Graph struct {
-    Nodes []Node `json:"nodes"`
-    Links []Link `json:"links"`
+	Nodes []Node `json:"nodes"`
+	Links []Link `json:"links"`
 }
 
 type Node struct {
-    ID string `json:"id"`
+	ID   string `json:"id"`
+	Type string `json:"type"`
 }
 
 type Link struct {
-    Source string `json:"source"`
-    Target string `json:"target"`
+	Source string `json:"source"`
+	Target string `json:"target"`
 }
 
 func main() {
-    r := mux.NewRouter()
+	r := mux.NewRouter()
 
-    r.HandleFunc("/api/graph", graphHandler).Methods("GET")
+	r.HandleFunc("/api/graph", graphHandler).Methods("GET")
 
-    // Serve static files from frontend/public
-    fs := http.FileServer(http.Dir("frontend/public"))
-    r.PathPrefix("/").Handler(fs)
+	// Serve static files from frontend/public
+	fs := http.FileServer(http.Dir("frontend/public"))
+	r.PathPrefix("/").Handler(fs)
 
-    log.Println("Server listening on :8080")
-    log.Fatal(http.ListenAndServe(":8080", r))
+	log.Println("Server listening on :8080")
+	log.Fatal(http.ListenAndServe(":8080", r))
 }
 
 func graphHandler(w http.ResponseWriter, r *http.Request) {
-    f, err := os.Open("data/graph.json")
-    if err != nil {
-        http.Error(w, err.Error(), http.StatusInternalServerError)
-        return
-    }
-    defer f.Close()
+	f, err := os.Open("data/graph.json")
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	defer f.Close()
 
-    var g Graph
-    if err := json.NewDecoder(f).Decode(&g); err != nil {
-        http.Error(w, err.Error(), http.StatusInternalServerError)
-        return
-    }
+	var g Graph
+	if err := json.NewDecoder(f).Decode(&g); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
 
-    w.Header().Set("Content-Type", "application/json")
-    json.NewEncoder(w).Encode(g)
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(g)
 }


### PR DESCRIPTION
## Summary
- add type field to node data
- download free icons from Heroicons
- render nodes with D3 using icon images based on node type
- expose node type in Go backend

## Testing
- `go build ./...`
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68886efc84c4832b9140502b540e7325