### PR TITLE
Add node name property and show labels

### DIFF
--- a/data/graph.json
+++ b/data/graph.json
@@ -1,9 +1,9 @@
 {
   "nodes": [
-    {"id": "A", "type": "net"},
-    {"id": "B", "type": "host"},
-    {"id": "C", "type": "rtr"},
-    {"id": "D", "type": "fw"}
+    {"id": "A", "type": "net", "name": "Network"},
+    {"id": "B", "type": "host", "name": "Host"},
+    {"id": "C", "type": "rtr", "name": "Router"},
+    {"id": "D", "type": "fw", "name": "Firewall"}
   ],
   "links": [
     {"source": "A", "target": "B"},

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -35,20 +35,27 @@ function draw(){
         .enter().append('line');
 
     const node = svg.append('g')
-        .selectAll('image')
+        .selectAll('g')
         .data(graph.nodes)
-        .enter().append('image')
-        .attr('href', d => icons[d.type])
-        .attr('width', 24)
-        .attr('height', 24)
-        .attr('x', -12)
-        .attr('y', -12)
+        .enter().append('g')
         .call(d3.drag()
             .on('start', dragstarted)
             .on('drag', dragged)
             .on('end', dragended));
 
-    node.append('title').text(d => d.id);
+    node.append('image')
+        .attr('href', d => icons[d.type])
+        .attr('width', 24)
+        .attr('height', 24)
+        .attr('x', -12)
+        .attr('y', -12);
+
+    node.append('text')
+        .attr('y', 20)
+        .attr('text-anchor', 'middle')
+        .text(d => d.name || d.id);
+
+    node.append('title').text(d => d.name || d.id);
 
     simulation.on('tick', () => {
         link.attr('x1', d => d.source.x)

--- a/server/main.go
+++ b/server/main.go
@@ -17,6 +17,7 @@ type Graph struct {
 type Node struct {
 	ID   string `json:"id"`
 	Type string `json:"type"`
+	Name string `json:"name"`
 }
 
 type Link struct {


### PR DESCRIPTION
## Summary
- include a new `name` field for each node in `Node` struct
- extend sample graph data with node names
- render node labels in the Svelte visualization

## Testing
- `cd server && gofmt -w main.go && go vet ./... && go build ./...`
- `cd frontend && npm install >/tmp/npm_install.log && npm run build >/tmp/npm_build.log`

------
https://chatgpt.com/codex/tasks/task_e_688870f1d870832ba22f9d5d3c1a1438