### PR TITLE
Update network node icon

### DIFF
--- a/frontend/public/icons/cloud.svg
+++ b/frontend/public/icons/cloud.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-slot="icon">
+  <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 15a4.5 4.5 0 0 0 4.5 4.5H18a3.75 3.75 0 0 0 1.332-7.257 3 3 0 0 0-3.758-3.848 5.25 5.25 0 0 0-10.233 2.33A4.502 4.502 0 0 0 2.25 15Z"/>
+</svg>

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -3,7 +3,7 @@ import { onMount } from 'svelte';
 import * as d3 from 'd3';
 
 const icons = {
-    net: '/icons/wifi.svg',
+    net: '/icons/cloud.svg',
     host: '/icons/computer-desktop.svg',
     rtr: '/icons/server-stack.svg',
     fw: '/icons/shield-check.svg'
@@ -45,10 +45,10 @@ function draw(){
 
     node.append('image')
         .attr('href', d => icons[d.type])
-        .attr('width', 24)
-        .attr('height', 24)
-        .attr('x', -12)
-        .attr('y', -12);
+        .attr('width', d => d.type === 'net' ? 96 : 24)
+        .attr('height', d => d.type === 'net' ? 96 : 24)
+        .attr('x', d => d.type === 'net' ? -48 : -12)
+        .attr('y', d => d.type === 'net' ? -48 : -12);
 
     node.append('text')
         .attr('y', 20)


### PR DESCRIPTION
## Summary
- add new `cloud.svg` icon for network nodes
- swap network icon to use the new cloud icon
- scale network icon to 4x other node icons

## Testing
- `npm install`
- `npm run build`
- `go build ./...`

------
https://chatgpt.com/codex/tasks/task_e_6888728b4690832bad5b639b728e381f