### PR TITLE
Update proxmoxsync to export VM info

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,5 +48,5 @@ docker compose run --rm netgraph ./proxmoxsync \
   -file mygraph.json -insecure
 ```
 
-The tool retrieves SDN networks, hosts, and the network interfaces each host is attached to. Networks and hosts are added as nodes while links between them represent the attached interfaces.
+The tool retrieves SDN networks, virtual machines, and the networks each VM is connected to. Networks and VMs are added as nodes while links between them represent the attached interfaces.
 


### PR DESCRIPTION
## Summary
- add VM query helpers for proxmoxsync
- link VMs to their bridged networks
- document VM behaviour in README

## Testing
- `go vet ./cmd/proxmoxsync`
- `go build` in `cmd/proxmoxsync`
- `go vet ./...` in `server`
- `go build` in `server`

------
https://chatgpt.com/codex/tasks/task_e_68889a942c14832b8f22d6e0c61f4593