### PR TITLE
Fix VMID parsing in Proxmox sync

### DIFF
--- a/cmd/proxmoxsync/main.go
+++ b/cmd/proxmoxsync/main.go
@@ -238,9 +238,9 @@ func getVMs(client *http.Client, host, ticket string) ([]vmInfo, error) {
 	}
 	var lr struct {
 		Data []struct {
-			VMID string `json:"vmid"`
-			Name string `json:"name"`
-			Node string `json:"node"`
+			VMID json.Number `json:"vmid"`
+			Name string      `json:"name"`
+			Node string      `json:"node"`
 		} `json:"data"`
 	}
 	if err := json.Unmarshal(body, &lr); err != nil {
@@ -248,8 +248,8 @@ func getVMs(client *http.Client, host, ticket string) ([]vmInfo, error) {
 	}
 	var vms []vmInfo
 	for _, d := range lr.Data {
-		if d.VMID != "" && d.Name != "" {
-			vms = append(vms, vmInfo{Node: d.Node, VMID: d.VMID, Name: d.Name})
+		if d.VMID.String() != "" && d.Name != "" {
+			vms = append(vms, vmInfo{Node: d.Node, VMID: d.VMID.String(), Name: d.Name})
 		}
 	}
 	return vms, nil


### PR DESCRIPTION
## Summary
- handle numeric VMID from Proxmox API by decoding to `json.Number`
- convert VMID to string when building internal VM list

## Testing
- `go build ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68889dbfeaf8832b8d1eca66467bb249