### PR TITLE
Fix zone detection in proxmoxsync

### DIFF
--- a/cmd/proxmoxsync/main.go
+++ b/cmd/proxmoxsync/main.go
@@ -238,8 +238,11 @@ func getZones(client *http.Client, host, ticket string) ([]string, error) {
 	}
 	var zones []string
 	for _, d := range lr.Data {
-		if d.ID != "" {
+		switch {
+		case d.ID != "":
 			zones = append(zones, d.ID)
+		case d.Zone != "":
+			zones = append(zones, d.Zone)
 		}
 	}
 	return zones, nil


### PR DESCRIPTION
## Summary
- fix parsing of zones in proxmoxsync

## Testing
- `go build`
- `go vet ./...` for proxmoxsync

------
https://chatgpt.com/codex/tasks/task_e_6888ac8bd324832bb9e48530c7e3df5a