### PR TITLE
Fix bridge and zone links in proxmoxsync

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,5 +50,5 @@ docker compose run --rm netgraph ./proxmoxsync \
 
 The tool retrieves SDN networks, virtual machines, and the networks each VM is connected to. Networks and VMs are added as nodes while links between them represent the attached interfaces.
 
-It also gathers SDN zones and bridge interfaces. Zones are added as `zone` nodes and bridges as `bridge` nodes. Networks are linked to their zone and bridge when that information is available.
+It also gathers SDN zones and bridge interfaces. Zones are added as `zone` nodes and bridges as `bridge` nodes. Networks are linked to their zone and bridge when that information is available. Host bridge interfaces are now detected and marked as `bridge` nodes.
 


### PR DESCRIPTION
## Summary
- detect host bridges when syncing from Proxmox
- mark VM interfaces as bridges
- document updated bridge handling

## Testing
- `go build ./...` in `cmd/proxmoxsync`
- `go build ./...` in `server`

------
https://chatgpt.com/codex/tasks/task_e_6888b05fd4f0832b90e6a4e1202007b0