### PR TITLE
Add VM node type

### DIFF
--- a/cmd/proxmoxsync/main.go
+++ b/cmd/proxmoxsync/main.go
@@ -142,7 +142,7 @@ func main() {
 
 	for _, v := range vms {
 		if _, ok := nodeSeen[v.Name]; !ok {
-			graph.Nodes = append(graph.Nodes, Node{ID: v.Name, Type: "host", Name: v.Name})
+			graph.Nodes = append(graph.Nodes, Node{ID: v.Name, Type: "vm", Name: v.Name})
 			nodeSeen[v.Name] = struct{}{}
 		}
 	}

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -5,6 +5,7 @@ import * as d3 from 'd3';
 const icons = {
     net: '/icons/cloud.svg',
     host: '/icons/computer-desktop.svg',
+    vm: '/icons/computer-desktop.svg',
     rtr: '/icons/server-stack.svg',
     fw: '/icons/shield-check.svg',
     zone: '/icons/wifi.svg',


### PR DESCRIPTION
## Summary
- support a new `vm` node type in the frontend icons map
- classify VMs as `vm` when building the graph from Proxmox

## Testing
- `cd cmd/proxmoxsync && go build . && cd ../..`


------
https://chatgpt.com/codex/tasks/task_e_6888b3eb7f98832bb7714d7d3e1dd554