### PR TITLE
Update host icon to server

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -4,7 +4,7 @@ import * as d3 from 'd3';
 
 const icons = {
     net: '/icons/cloud.svg',
-    host: '/icons/computer-desktop.svg',
+    host: '/icons/server-stack.svg',
     vm: '/icons/computer-desktop.svg',
     rtr: '/icons/server-stack.svg',
     fw: '/icons/shield-check.svg',


### PR DESCRIPTION
## Summary
- tweak Svelte icon mapping for host nodes

## Testing
- `npm run build` in `frontend`
- `go build ./...` (server)
- `go vet ./...` (server)
- `go build ./...` (cmd/proxmoxsync)
- `go vet ./...` (cmd/proxmoxsync)


------
https://chatgpt.com/codex/tasks/task_e_6888b5f76940832b8fa060b063a56e50