### PR TITLE
Increase highlight path width

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -112,6 +112,7 @@ function draw(){
 
     linkSelection = container.append('g')
         .attr('stroke', '#999')
+        .attr('stroke-width', 1)
         .selectAll('line')
         .data(graph.links)
         .enter().append('line');
@@ -211,7 +212,9 @@ function updateHighlights(){
     nodeSelection.select('image')
         .classed('selected', d => selectedNodes.includes(d))
         .classed('located', d => highlightedNode && d.id === highlightedNode.id);
-    linkSelection.attr('stroke', d => pathLinks.includes(d) ? pathColor : '#999');
+    linkSelection
+        .attr('stroke', d => pathLinks.includes(d) ? pathColor : '#999')
+        .attr('stroke-width', d => pathLinks.includes(d) ? 3 : 1);
 }
 
 function highlightFromList(){


### PR DESCRIPTION
## Summary
- make link width customizable based on highlight state
- set highlighted path lines 3x thicker

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68895df3aa88832bbc0d129a9dcbd8ba