### PR TITLE
Enhance node info handling

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -36,6 +36,8 @@ let showHide = false;
 let typeHide = [];
 let hiddenTypes = new Set(['disk']);
 let fixMode = false;
+let showInfo = false;
+let infoNode = null;
 
 function nodeType(nodeRef){
     if(typeof nodeRef === 'object' && nodeRef !== null){
@@ -153,6 +155,7 @@ function draw(){
             .on('drag', dragged)
             .on('end', dragended));
     nodeSelection.on('click', nodeClicked);
+    nodeSelection.on('dblclick', nodeDblClicked);
 
     nodeSelection.append('image')
         .attr('href', d => icons[d.type])
@@ -273,6 +276,11 @@ function nodeClicked(event, d){
     updateHighlights();
 }
 
+function nodeDblClicked(event, d){
+    infoNode = d;
+    showInfo = true;
+}
+
 function applyWeights() {
     graph.links.forEach(l => {
         const sType = nodeType(l.source);
@@ -371,6 +379,17 @@ function applyHide() {
             <div class="buttons">
                 <button on:click={applyHide}>Apply</button>
                 <button on:click={() => showHide = false}>Close</button>
+            </div>
+        </div>
+    </div>
+    {/if}
+    {#if showInfo}
+    <div class="dialog">
+        <div class="dialog-content">
+            <h3>{infoNode.name || infoNode.id}</h3>
+            <pre>{JSON.stringify(infoNode.info || {}, null, 2)}</pre>
+            <div class="buttons">
+                <button on:click={() => showInfo = false}>Close</button>
             </div>
         </div>
     </div>

--- a/server/main.go
+++ b/server/main.go
@@ -16,9 +16,10 @@ type Graph struct {
 }
 
 type Node struct {
-	ID   string `json:"id"`
-	Type string `json:"type"`
-	Name string `json:"name"`
+        ID   string                 `json:"id"`
+        Type string                 `json:"type"`
+        Name string                 `json:"name"`
+        Info map[string]interface{} `json:"info,omitempty"`
 }
 
 type Link struct {


### PR DESCRIPTION
## Summary
- extend node structs with `info` map
- fetch additional details from Proxmox hosts, networks and VMs
- expose node info in graph JSON
- show info dialog when double-clicking a node in the UI

## Testing
- `go vet ./...` in `server`
- `go vet ./...` in `cmd/proxmoxsync`
- `go build` in `cmd/proxmoxsync`
- `go build` in `server`
- `npm run build` in `frontend`

------
https://chatgpt.com/codex/tasks/task_e_688997a94a48832b91438a478aab8722