### PR TITLE
Add node info data and frontend details dialog

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -36,6 +36,8 @@ let showHide = false;
 let typeHide = [];
 let hiddenTypes = new Set(['disk']);
 let fixMode = false;
+let showInfo = false;
+let infoNode = null;
 
 function nodeType(nodeRef){
     if(typeof nodeRef === 'object' && nodeRef !== null){
@@ -152,7 +154,8 @@ function draw(){
             .on('start', dragstarted)
             .on('drag', dragged)
             .on('end', dragended));
-    nodeSelection.on('click', nodeClicked);
+    nodeSelection.on('click', nodeClicked)
+        .on('dblclick', nodeDblClicked);
 
     nodeSelection.append('image')
         .attr('href', d => icons[d.type])
@@ -273,6 +276,11 @@ function nodeClicked(event, d){
     updateHighlights();
 }
 
+function nodeDblClicked(event, d){
+    infoNode = d;
+    showInfo = true;
+}
+
 function applyWeights() {
     graph.links.forEach(l => {
         const sType = nodeType(l.source);
@@ -371,6 +379,21 @@ function applyHide() {
             <div class="buttons">
                 <button on:click={applyHide}>Apply</button>
                 <button on:click={() => showHide = false}>Close</button>
+            </div>
+        </div>
+    </div>
+    {/if}
+    {#if showInfo}
+    <div class="dialog">
+        <div class="dialog-content">
+            <h3>{infoNode.name || infoNode.id}</h3>
+            <table>
+                {#each Object.entries(infoNode.info || {}) as kv}
+                <tr><td>{kv[0]}</td><td>{kv[1]}</td></tr>
+                {/each}
+            </table>
+            <div class="buttons">
+                <button on:click={() => showInfo = false}>Close</button>
             </div>
         </div>
     </div>

--- a/server/main.go
+++ b/server/main.go
@@ -16,9 +16,10 @@ type Graph struct {
 }
 
 type Node struct {
-	ID   string `json:"id"`
-	Type string `json:"type"`
-	Name string `json:"name"`
+	ID   string            `json:"id"`
+	Type string            `json:"type"`
+	Name string            `json:"name"`
+	Info map[string]string `json:"info,omitempty"`
 }
 
 type Link struct {


### PR DESCRIPTION
## Summary
- collect extra VM, host and network details in `proxmoxsync`
- store node information in the graph JSON
- extend server to expose node info
- show a dialog with node info on double‑click in the UI

## Testing
- `go vet ./...` in `server` and `cmd/proxmoxsync`
- `go build` in `cmd/proxmoxsync` and `server`
- `npm run build` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_688997a94a48832b91438a478aab8722