### PR TITLE
Add per-node hide/show

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ displayed:
   simulation runs.
 * **Path colour picker** – select the colour used when highlighting paths
   between two nodes.
+* **Hide Types** – open a dialog to toggle visibility of each node type.
+* **Hide Nodes** – open a dialog to hide or show specific nodes by name.
 
 The graph supports mouse wheel zooming and panning by dragging empty space. You
 can drag nodes to reposition them. Clicking two nodes highlights the path


### PR DESCRIPTION
## Summary
- allow hiding/showing individual nodes in the graph
- document Hide Types and Hide Nodes UI options

## Testing
- `npm install`
- `npm run build`
- `go vet ./...`

------
https://chatgpt.com/codex/tasks/task_e_6889b9a3b560832b8b63d2b621ce4b83