### PR TITLE
Add navbar and sidebar

### DIFF
--- a/frontend/public/global.css
+++ b/frontend/public/global.css
@@ -5,9 +5,9 @@ html, body {
 }
 
 body {
-	color: #333;
-	margin: 0;
-	padding: 8px;
+        color: #333;
+        margin: 0;
+        padding: 0;
 	box-sizing: border-box;
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 }

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -1,6 +1,8 @@
 <script>
 import { onMount } from 'svelte';
 import * as d3 from 'd3';
+import Navbar from './components/Navbar.svelte';
+import Sidebar from './components/Sidebar.svelte';
 
 const icons = {
     net: '/icons/cloud.svg',
@@ -330,7 +332,10 @@ function applyHideNodes() {
 }
 </script>
 
-<main>
+<Navbar />
+<div class="layout">
+    <Sidebar />
+    <main>
     <div style="position:absolute;top:10px;left:10px;z-index:10;background:white;padding:4px;border-radius:4px;">
         <select bind:value={selectedFile} on:change={loadGraph}>
             {#each files as f}
@@ -438,8 +443,14 @@ function applyHideNodes() {
     {/if}
     <svg id="graph" style="width:100%; height:100%;"></svg>
 </main>
+</div>
 
 <style>
+.layout {
+    display: flex;
+    height: calc(100vh - 50px);
+}
+
 main,
 svg {
     width: 100%;
@@ -448,6 +459,7 @@ svg {
 
 main {
     position: relative;
+    flex: 1;
 }
 
 svg {

--- a/frontend/src/components/Navbar.svelte
+++ b/frontend/src/components/Navbar.svelte
@@ -1,0 +1,61 @@
+<script>
+  export let logo = '/icons/cloud.svg';
+</script>
+
+<nav class="navbar">
+  <div class="nav-left">
+    <img class="logo" src={logo} alt="Logo" />
+    <span class="title">NetGraph</span>
+  </div>
+  <div class="nav-right">
+    <img class="avatar" src="https://placekitten.com/40/40" alt="Avatar" />
+  </div>
+</nav>
+
+<style>
+.navbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 1rem;
+  height: 50px;
+  background: white;
+  position: relative;
+  border-bottom: 1px solid #e5e7eb;
+}
+
+.navbar::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: -1px;
+  height: 6px;
+  border-bottom-left-radius: 8px;
+  border-bottom-right-radius: 8px;
+  background: linear-gradient(to right, #3b82f6, #9333ea);
+}
+
+.nav-left {
+  display: flex;
+  align-items: center;
+}
+
+.logo {
+  width: 24px;
+  height: 24px;
+  margin-right: 0.5rem;
+}
+
+.title {
+  font-weight: bold;
+  font-size: 1.2rem;
+}
+
+.avatar {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+}
+</style>
+

--- a/frontend/src/components/Sidebar.svelte
+++ b/frontend/src/components/Sidebar.svelte
@@ -1,0 +1,35 @@
+<script>
+  const icons = [
+    'cloud.svg',
+    'server-stack.svg',
+    'computer-desktop.svg',
+    'router-network.svg',
+    'shield-check.svg'
+  ];
+</script>
+
+<aside class="sidebar">
+  {#each icons as icon}
+    <img src={'/icons/' + icon} alt={icon} />
+  {/each}
+</aside>
+
+<style>
+.sidebar {
+  width: 60px;
+  background: white;
+  padding-top: 1rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  border-right: 1px solid #e5e7eb;
+  box-shadow: 2px 0 4px rgba(0,0,0,0.1);
+}
+
+.sidebar img {
+  width: 24px;
+  height: 24px;
+  margin: 0.75rem 0;
+}
+</style>
+


### PR DESCRIPTION
## Summary
- add a Flowbite-style navbar with gradient bottom
- add sidebar with vertical icons
- integrate layout into `App.svelte`
- remove body padding for full-screen layout

## Testing
- `npm install`
- `npm run build`
- `gofmt -w main.go`
- `go build ./...`

------
https://chatgpt.com/codex/tasks/task_e_688be9383930832bbe11d5b62ca8b62d