### PR TITLE
Move json selector to dialog on cloud icon

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -19,6 +19,7 @@ const icons = {
 let graph = {nodes:[], links:[]};
 let files = [];
 let selectedFile = '';
+let showFileDialog = false;
 let showWeights = false;
 let typeWeights = [];
 let showAttract = false;
@@ -334,14 +335,9 @@ function applyHideNodes() {
 
 <Navbar />
 <div class="layout">
-    <Sidebar />
+    <Sidebar on:openFileDialog={() => showFileDialog = true} />
     <main>
     <div style="position:absolute;top:10px;left:10px;z-index:10;background:white;padding:4px;border-radius:4px;">
-        <select bind:value={selectedFile} on:change={loadGraph}>
-            {#each files as f}
-                <option value={f}>{f}</option>
-            {/each}
-        </select>
         <button on:click={openWeightsDialog} style="margin-left:4px;">Weights</button>
         <button on:click={openAttractDialog} style="margin-left:4px;">Attractiveness</button>
         <button on:click={openHideDialog} style="margin-left:4px;">Hide Types</button>
@@ -357,6 +353,22 @@ function applyHideNodes() {
             {/each}
         </select>
     </div>
+    {#if showFileDialog}
+    <div class="dialog">
+        <div class="dialog-content">
+            <h3>Select Graph File</h3>
+            <select bind:value={selectedFile} style="margin-bottom:4px;width:100%;">
+                {#each files as f}
+                    <option value={f}>{f}</option>
+                {/each}
+            </select>
+            <div class="buttons">
+                <button on:click={() => { loadGraph(); showFileDialog = false; }}>Open</button>
+                <button on:click={() => showFileDialog = false}>Close</button>
+            </div>
+        </div>
+    </div>
+    {/if}
     {#if showWeights}
     <div class="dialog">
         <div class="dialog-content">

--- a/frontend/src/components/Sidebar.svelte
+++ b/frontend/src/components/Sidebar.svelte
@@ -1,4 +1,7 @@
 <script>
+  import { createEventDispatcher } from 'svelte';
+  const dispatch = createEventDispatcher();
+
   const icons = [
     'cloud.svg',
     'server-stack.svg',
@@ -6,11 +9,17 @@
     'router-network.svg',
     'shield-check.svg'
   ];
+
+  function clickIcon(index) {
+    if (index === 0) {
+      dispatch('openFileDialog');
+    }
+  }
 </script>
 
 <aside class="sidebar">
-  {#each icons as icon}
-    <img src={'/icons/' + icon} alt={icon} />
+  {#each icons as icon, i}
+    <img src={'/icons/' + icon} alt={icon} on:click={() => clickIcon(i)} />
   {/each}
 </aside>
 


### PR DESCRIPTION
## Summary
- add file selector dialog
- trigger the dialog from Sidebar cloud icon

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688bebe0140c832bb57ec4bdfa85a8fc